### PR TITLE
[Fix] Propose fix for broken link

### DIFF
--- a/_pages/about.md
+++ b/_pages/about.md
@@ -8,7 +8,7 @@ Developers love meet-ups. Almost every programming language has its own local me
 
 Talk.CSS came into being on October 26, 2015. It all started from a random conversation in our local digital watering hole, the [KopiJS](http://kopijs.org/) slack channel. The idea of starting a CSS meet-up seemed to take quite well and by 4pm we already had a logo, a GitHub organisation, a Twitter account and the venue for our inaugural meet-up.
 
-The meetup was started and run by [Chen Hui Jing](https://twitter.com/hj_chen) and [Chris Lienert](https://twitter.com/cliener). Chris left Singapore to return to Australia after [Talk.CSS #34]({{ site.url }}/34). But after 3 months of flying solo, we lucked out and found a new co-organiser, [Gao Wei](s://twitter.com/wgao19).
+The meetup was started and run by [Chen Hui Jing](https://twitter.com/hj_chen) and [Chris Lienert](https://twitter.com/cliener). Chris left Singapore to return to Australia after [Talk.CSS #34]({{ site.url }}/34). But after 3 months of flying solo, we lucked out and found a new co-organiser, [Gao Wei](https://twitter.com/wgao19).
 
 <figure class="c-content__fig">
     <figcaption>It all started here...</figcaption>


### PR DESCRIPTION
`s://twitter.com/wgao19` becomes `file:///S://twitter.com/wgao19` in Chrome and Edge. This PR adds the `https` protocol in its entirety to fix that

![Untitled](https://user-images.githubusercontent.com/3222800/60828581-59577f80-a1e5-11e9-8caf-f42b5d9b9f43.png)